### PR TITLE
Remove parentheses in CSV output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn generate(
             .iter()
             .map(|x| {
                 x.iter()
-                    .map(|z| format!("{:?}", *z))
+                    .map(|z| format!("{:?},{:?}", (*z).0, (*z).1))
                     .collect::<Vec<String>>()
                     .join(",")
             })


### PR DESCRIPTION
CSV output currently looks like `(0,1),(2,3)`, but original code outputs flat CSV files in the form `0,1,2,3`. This emulates the original library better